### PR TITLE
limit torch version for cuda compute capability of runner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 dependencies = [
     "numpy",
     "einops",
-    "torch",  # limit torch version for compatibility with GPU-runner
+    "torch",
     "torch-fourier-slice",
     "torch-grid-utils>=0.0.8",
     "torch-affine-utils",


### PR DESCRIPTION
It seems the latest pytorch version no longer supports hardware with CUDA compute capability <7. The GTX 1080 of the GPU runner has compute capability 6.1. This might mean we need to limit the torch version to <=2.8, that would not be ideal...