### PR TITLE
Feature/performance

### DIFF
--- a/examples/reconstruct_from_aretomo.py
+++ b/examples/reconstruct_from_aretomo.py
@@ -1,0 +1,61 @@
+import alnfile
+import mrcfile
+import numpy as np
+from pathlib import Path
+from torch_tomogram import Tomogram
+
+# Paths
+ALN_PATH = Path('/Path/to/your/alnfile.aln')
+TILT_STACK_PATH = Path('/Path/to/your/raw/tilt_stack.ts_ext')
+
+# Read AreTomo alignment data
+df = alnfile.read(ALN_PATH)
+
+# Get shifts for reconstruction 
+# In aretomo tx and ty already represents the shifts in the forward projection model (sample -> image) 
+# so we can either use directly those
+corrected_shifts_t_xy = df[['tx', 'ty']].to_numpy()
+corrected_shifts_t_yx = corrected_shifts_t_xy[:, ::-1].copy() #yx
+
+# or get IMOD xf components from the dataframe
+# df_to_xf(df, yx=True) returns (n_tilts, 2, 3) array
+# Each matrix is [[A22, A21, DY], [A12, A11, DX]] (ready for torch-tomogram yz) 
+xf = alnfile.df_to_xf(df, yx=True)
+m, shifts = xf[:, :, :2], xf[:, :, 2]
+# Convert IMOD's backward projection model to torch-tomogram's forward model
+# IMOD: image -> sample
+#   > the 2d matrix from the .xf file represents a 2d transform to align
+#   > the image with the tilt-axis
+# torch-tomogram: sample -> image
+#   > the shifts are applied after rotation and projection and shift the
+#   > projected sample to the image position
+#
+#  Roation matrix are orthogonal, so inversion = transposition :
+#  np.einsum('nij,nj->ni', np.linalg.inv(m), shifts) = np.einsum('nji,nj->ni', m, shifts) 
+#
+#  Negate shifts for forward projection model
+corrected_shifts_xf = -np.einsum('nji,nj->ni', m, shifts)
+
+# Load tilt stack
+tilt_stack_full = mrcfile.read(TILT_STACK_PATH)
+
+included_indices = df['sec'].values - 1  # 0-indexed section indices
+tilt_stack = tilt_stack_full[included_indices]
+
+# Normalize
+tilt_stack -= np.mean(tilt_stack, axis=(-2, -1), keepdims=True)
+tilt_stack /= np.std(tilt_stack, axis=(-2, -1), keepdims=True) 
+
+# Build tomogram and reconstruct
+tilt_series = Tomogram(
+    images=tilt_stack,
+    tilt_angles=df['tilt'].to_numpy(),
+    tilt_axis_angle=df['rot'].to_numpy(),  # Use single tilt axis angle
+    sample_translations=corrected_shifts_xf.copy() # or corrected_shifts_t_yx.copy()
+) 
+
+tomogram = tilt_series.reconstruct_tomogram((100, 480, 320), 128)
+
+# Save tomogram
+out_path = ALN_PATH.parent / 'tt_rec.mrc'
+mrcfile.write(out_path, tomogram.numpy(), overwrite=True, voxel_size=10)

--- a/examples/reconstruct_from_aretomo.py
+++ b/examples/reconstruct_from_aretomo.py
@@ -12,29 +12,9 @@ TILT_STACK_PATH = Path('/Path/to/your/raw/tilt_stack.ts_ext')
 df = alnfile.read(ALN_PATH)
 
 # Get shifts for reconstruction 
-# In aretomo tx and ty already represents the shifts in the forward projection model (sample -> image) 
-# so we can either use directly those
+# In aretomo, tx and ty already represent the shifts in the forward projection model (sample -> image) 
 corrected_shifts_t_xy = df[['tx', 'ty']].to_numpy()
 corrected_shifts_t_yx = corrected_shifts_t_xy[:, ::-1].copy() #yx
-
-# or get IMOD xf components from the dataframe
-# df_to_xf(df, yx=True) returns (n_tilts, 2, 3) array
-# Each matrix is [[A22, A21, DY], [A12, A11, DX]] (ready for torch-tomogram yz) 
-xf = alnfile.df_to_xf(df, yx=True)
-m, shifts = xf[:, :, :2], xf[:, :, 2]
-# Convert IMOD's backward projection model to torch-tomogram's forward model
-# IMOD: image -> sample
-#   > the 2d matrix from the .xf file represents a 2d transform to align
-#   > the image with the tilt-axis
-# torch-tomogram: sample -> image
-#   > the shifts are applied after rotation and projection and shift the
-#   > projected sample to the image position
-#
-#  Roation matrix are orthogonal, so inversion = transposition :
-#  np.einsum('nij,nj->ni', np.linalg.inv(m), shifts) = np.einsum('nji,nj->ni', m, shifts) 
-#
-#  Negate shifts for forward projection model
-corrected_shifts_xf = -np.einsum('nji,nj->ni', m, shifts)
 
 # Load tilt stack
 tilt_stack_full = mrcfile.read(TILT_STACK_PATH)
@@ -50,8 +30,8 @@ tilt_stack /= np.std(tilt_stack, axis=(-2, -1), keepdims=True)
 tilt_series = Tomogram(
     images=tilt_stack,
     tilt_angles=df['tilt'].to_numpy(),
-    tilt_axis_angle=df['rot'].to_numpy(),  # Use single tilt axis angle
-    sample_translations=corrected_shifts_xf.copy() # or corrected_shifts_t_yx.copy()
+    tilt_axis_angle=df['rot'].to_numpy(), 
+    sample_translations=corrected_shifts_xf.copy()
 ) 
 
 tomogram = tilt_series.reconstruct_tomogram((100, 480, 320), 128)

--- a/examples/reconstruct_from_aretomo.py
+++ b/examples/reconstruct_from_aretomo.py
@@ -1,3 +1,4 @@
+import alnfile
 import mrcfile
 import torch
 from pathlib import Path
@@ -11,15 +12,17 @@ TILT_STACK_PATH = Path("/path/to/your/tilt_stack.mrc")
 # Choose device
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
-# Optional: Pixel spacing in Angstroms
+# Pixel spacing in Angstroms (required)
 # AreTomo .aln files contain shifts in pixels, this converts them to Angstroms
-# If None, shifts remain in pixels
 PIXEL_SPACING = 6.192
 
-# Load tilt series
-tilt_series = Tomogram.from_aretomo_aln(
-    aln_path=ALN_PATH,
-    tilt_stack_path=TILT_STACK_PATH,
+# Read AreTomo alignment data and add tilt stack path to dataframe
+df = alnfile.read(ALN_PATH)
+df['image_path'] = str(TILT_STACK_PATH)
+
+# Load tilt series from dataframe
+tilt_series = Tomogram.from_aretomo_output(
+    df=df,
     pixel_spacing=PIXEL_SPACING,
     device=DEVICE,
 )
@@ -35,5 +38,5 @@ mrcfile.write(
     output_path,
     tomogram.cpu().numpy(),
     overwrite=True,
-    voxel_size=10,
+    voxel_size=PIXEL_SPACING,
 )

--- a/examples/reconstruct_from_aretomo.py
+++ b/examples/reconstruct_from_aretomo.py
@@ -1,41 +1,39 @@
-import alnfile
 import mrcfile
-import numpy as np
+import torch
 from pathlib import Path
 from torch_tomogram import Tomogram
 
-# Paths
-ALN_PATH = Path('/Path/to/your/alnfile.aln')
-TILT_STACK_PATH = Path('/Path/to/your/raw/tilt_stack.ts_ext')
 
-# Read AreTomo alignment data
-df = alnfile.read(ALN_PATH)
+# Paths to AreTomo alignment file and raw tilt stack
+ALN_PATH = Path("/path/to/your/alignment.aln")
+TILT_STACK_PATH = Path("/path/to/your/tilt_stack.mrc")
 
-# Get shifts for reconstruction 
-# In aretomo, tx and ty already represent the shifts in the forward projection model (sample -> image) 
-corrected_shifts_t_xy = df[['tx', 'ty']].to_numpy()
-corrected_shifts_t_yx = corrected_shifts_t_xy[:, ::-1].copy() #yx
+# Choose device
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
-# Load tilt stack
-tilt_stack_full = mrcfile.read(TILT_STACK_PATH)
+# Optional: Pixel spacing in Angstroms
+# AreTomo .aln files contain shifts in pixels, this converts them to Angstroms
+# If None, shifts remain in pixels
+PIXEL_SPACING = 6.192
 
-included_indices = df['sec'].values - 1  # 0-indexed section indices
-tilt_stack = tilt_stack_full[included_indices]
+# Load tilt series
+tilt_series = Tomogram.from_aretomo_aln(
+    aln_path=ALN_PATH,
+    tilt_stack_path=TILT_STACK_PATH,
+    pixel_spacing=PIXEL_SPACING,
+    device=DEVICE,
+)
 
-# Normalize
-tilt_stack -= np.mean(tilt_stack, axis=(-2, -1), keepdims=True)
-tilt_stack /= np.std(tilt_stack, axis=(-2, -1), keepdims=True) 
+# Reconstruct tomogram
+volume_shape = (512, 512, 512)
+sidelength = 128
+tomogram = tilt_series.reconstruct_tomogram(volume_shape, sidelength)
 
-# Build tomogram and reconstruct
-tilt_series = Tomogram(
-    images=tilt_stack,
-    tilt_angles=df['tilt'].to_numpy(),
-    tilt_axis_angle=df['rot'].to_numpy(), 
-    sample_translations=corrected_shifts_xf.copy()
-) 
-
-tomogram = tilt_series.reconstruct_tomogram((100, 480, 320), 128)
-
-# Save tomogram
-out_path = ALN_PATH.parent / 'tt_rec.mrc'
-mrcfile.write(out_path, tomogram.numpy(), overwrite=True, voxel_size=10)
+# Save as MRC file
+output_path = ALN_PATH.parent / 'torch_tomogram_reconstruction.mrc'
+mrcfile.write(
+    output_path,
+    tomogram.cpu().numpy(),
+    overwrite=True,
+    voxel_size=10,
+)

--- a/examples/reconstruct_from_etomo.py
+++ b/examples/reconstruct_from_etomo.py
@@ -1,53 +1,39 @@
-import etomofiles
 import mrcfile
-import numpy as np
+import torch
 from pathlib import Path
 from torch_tomogram import Tomogram
 
 
-# Read etomo alignment data
+# Path to ETOMO project directory
 ETOMO_DIR = Path("/path/to/etomo/dir")
 
-df = etomofiles.read(ETOMO_DIR)
-# Filter out excluded tilts
-df = df.loc[~df['excluded']].reset_index(drop=True)
+# Choose device: "cpu" or "cuda" 
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
-# Get IMOD xf components from dataframe
-# df_to_xf(df, yx=True) returns (n_tilts, 2, 3) array
-# Each matrix is [[A22, A21, DY], [A12, A11, DX]] (ready for torch-tomogram yz) 
-xf = etomofiles.df_to_xf(df, yx=True)
-m, shifts = xf[:, :, :2], xf[:, :, 2]
-# Convert IMOD's backward projection model to torch-tomogram's forward model
-# IMOD: image -> sample
-#   > the 2d matrix from the .xf file represents a 2d transform to align
-#   > the image with the tilt-axis
-# torch-tomogram: sample -> image
-#   > the shifts are applied after rotation and projection and shift the
-#   > projected sample to the image position
-#
-#  Roation matrix are orthogonal, so inversion = transposition :
-#  np.einsum('nij,nj->ni', np.linalg.inv(m), shifts) = np.einsum('nji,nj->ni', m, shifts) 
-#
-#  Negate shifts for forward projection model
-corrected_shifts = -np.einsum('nji,nj->ni', m, shifts)
-corrected_shifts = np.ascontiguousarray(corrected_shifts)
+# Optional: Pixel spacing in Angstroms
+# If provided, shifts from alignment will be stored in Angstroms
+# If None, shifts remain in pixels 
+PIXEL_SPACING = 6.192
 
-# Load and normalize tilt stack
-tilt_stack_path = ETOMO_DIR / df.image_path[0].replace('[0]', '')
-tilt_stack_full = mrcfile.read(tilt_stack_path)
-# Filter stack to only included tilts
-tilt_stack = tilt_stack_full[df.idx_tilt.to_numpy()]
-#Zero-mean, unit-variance normalization per image
-tilt_stack -= np.mean(tilt_stack, axis=(-2, -1), keepdims=True)
-tilt_stack /= np.std(tilt_stack, axis=(-2, -1), keepdims=True)
-
-# Create tomogram object and reconstruct
-tilt_series = Tomogram(
-    images=tilt_stack,
-    tilt_angles=df.tlt,
-    tilt_axis_angle=df.tilt_axis_angle,
-    sample_translations=corrected_shifts.copy()
+# Load tilt series
+tilt_series = Tomogram.from_etomo_directory(
+    etomo_dir=ETOMO_DIR,
+    pixel_spacing=PIXEL_SPACING,
+    device=DEVICE,
 )
-tomogram = tilt_series.reconstruct_tomogram((100, 480, 380), 128)
 
-mrcfile.write(ETOMO_DIR / 'tt_rec.mrc', tomogram.numpy(), overwrite=True, voxel_size=10)
+
+# Reconstruct tomogram
+volume_shape = (512, 512, 512)
+sidelength = 128
+tomogram = tilt_series.reconstruct_tomogram(volume_shape, sidelength)
+
+# Save as MRC file
+output_path = ETOMO_DIR / 'torch_tomogram_reconstruction.mrc'
+mrcfile.write(
+    output_path,
+    tomogram.cpu().numpy(),
+    overwrite=True,
+    voxel_size=10,
+)
+

--- a/src/torch_tomogram/tomogram.py
+++ b/src/torch_tomogram/tomogram.py
@@ -1,12 +1,18 @@
 """Tomogram reconstruction in pytorch."""
 
+from pathlib import Path
+
+import etomofiles
+import alnfile
+import mrcfile
 import einops
+import numpy as np
 import torch
 import torch.nn.functional as F
 from torch_affine_utils import homogenise_coordinates
 from torch_affine_utils.transforms_3d import Ry, Rz, T
-from torch_fourier_slice import backproject_2d_to_3d
-from torch_grid_utils import dft_center
+from torch_fourier_slice import insert_central_slices_rfft_3d_multichannel
+from torch_grid_utils import dft_center, fftfreq_grid
 from torch_subpixel_crop import subpixel_crop_2d
 
 
@@ -19,6 +25,7 @@ class Tomogram:
         tilt_axis_angle: torch.Tensor,
         sample_translations: torch.Tensor,
         images: torch.Tensor,  # (b, h, w)
+        pixel_spacing: float | None = None,
         device: torch.device | str = "cpu",
     ):
         self.images = torch.as_tensor(images, device=device).float()
@@ -27,13 +34,95 @@ class Tomogram:
         self.sample_translations = torch.as_tensor(
             sample_translations, device=device
         ).float()
+        self.pixel_spacing = pixel_spacing
         self.device = device
         self._pad_factor = 2.0
+    
+    @property
+    def sample_translations_px(self) -> torch.Tensor:
+        """Get sample translations in pixels.
+        
+        If pixel_spacing was provided, converts from Angstroms to pixels.
+        Otherwise, returns the translations as-is (already in pixels).
+        """
+        if self.pixel_spacing is not None:
+            return self.sample_translations / self.pixel_spacing
+        return self.sample_translations
+
+    @classmethod
+    def from_aretomo_aln(
+        cls,
+        aln_path: Path | str,
+        tilt_stack_path: Path | str,
+        pixel_spacing: float | None = None,
+        device: torch.device | str = "cpu",
+    ) -> "Tomogram":
+        """Initialize Tomogram from AreTomo alignment file and tilt stack."""
+
+        aln_path = Path(aln_path)
+        tilt_stack_path = Path(tilt_stack_path)
+        df = alnfile.read(aln_path)
+        corrected_shifts_xy = df[["tx", "ty"]].to_numpy()
+        corrected_shifts_yx = corrected_shifts_xy[:, ::-1].copy()
+        
+        # Convert shifts to Angstroms if pixel_spacing provided
+        if pixel_spacing is not None:
+            corrected_shifts_yx = corrected_shifts_yx * pixel_spacing
+        
+        tilt_stack_full = mrcfile.read(tilt_stack_path)
+        included_indices = df["sec"].values - 1 
+        tilt_stack = tilt_stack_full[included_indices]
+        tilt_stack = tilt_stack.astype(np.float32)
+        tilt_stack -= np.mean(tilt_stack, axis=(-2, -1), keepdims=True)
+        tilt_stack /= np.std(tilt_stack, axis=(-2, -1), keepdims=True)
+        return cls(
+            images=tilt_stack,
+            tilt_angles=df["tilt"].to_numpy(),
+            tilt_axis_angle=df["rot"].to_numpy(),
+            sample_translations=corrected_shifts_yx,
+            pixel_spacing=pixel_spacing,
+            device=device,
+        )
+
+    @classmethod
+    def from_etomo_directory(
+        cls,
+        etomo_dir: Path | str,
+        pixel_spacing: float | None = None,
+        device: torch.device | str = "cpu",
+    ) -> "Tomogram":
+        """Initialize Tomogram from ETOMO directory."""
+
+        etomo_dir = Path(etomo_dir)
+        df = etomofiles.read(etomo_dir)
+        df = df.loc[~df["excluded"]].reset_index(drop=True)
+        xf = etomofiles.df_to_xf(df, yx=True)
+        m, shifts = xf[:, :, :2], xf[:, :, 2]
+        corrected_shifts = -np.einsum("nji,nj->ni", m, shifts)
+        corrected_shifts = np.ascontiguousarray(corrected_shifts)
+        # Convert shifts to Angstroms if pixel_spacing is available
+        if pixel_spacing is not None:
+            corrected_shifts = corrected_shifts * pixel_spacing
+        tilt_stack_path = etomo_dir / df.image_path[0].replace("[0]", "")
+        tilt_stack_full = mrcfile.read(tilt_stack_path)
+        tilt_stack = tilt_stack_full[df.idx_tilt.to_numpy()]
+        tilt_stack = tilt_stack.astype(np.float32)
+        tilt_stack -= np.mean(tilt_stack, axis=(-2, -1), keepdims=True)
+        tilt_stack /= np.std(tilt_stack, axis=(-2, -1), keepdims=True)
+
+        return cls(
+            images=tilt_stack,
+            tilt_angles=df.tlt.to_numpy(),
+            tilt_axis_angle=df.tilt_axis_angle.to_numpy(),
+            sample_translations=corrected_shifts,
+            pixel_spacing=pixel_spacing,
+            device=device,
+        )
 
     @property
     def projection_matrices(self) -> torch.Tensor:
         """Matrices that project points from 3D -> 2D."""
-        shifts_3d = F.pad(self.sample_translations, (1, 0), value=0)
+        shifts_3d = F.pad(self.sample_translations_px, (1, 0), value=0)
         r0 = Ry(self.tilt_angles, zyx=True, device=self.device)
         r1 = Rz(self.tilt_axis_angle, zyx=True, device=self.device)
         t2 = T(shifts_3d, device=self.device)
@@ -66,7 +155,7 @@ class Tomogram:
         return projected_yx  # (points, tilts, yx)
 
     def extract_particle_tilt_series(
-        self, points_zyx: torch.Tensor, sidelength: int
+        self, points_zyx: torch.Tensor, sidelength: int, return_rfft: bool = True
     ) -> torch.Tensor:
         """Extract a subtilt-series at a 3D location in the sample."""
         projected_yx = self.project_points(points_zyx)
@@ -77,63 +166,116 @@ class Tomogram:
             image=self.images,
             positions=projected_yx,
             sidelength=sidelength,
+            return_rfft=return_rfft,
+            decenter=return_rfft,  
         )
         return images
 
     def reconstruct_subvolume(
         self, point_zyx: torch.Tensor, sidelength: int
     ) -> torch.Tensor:
-        """Reconstruct a subvolume at a 3D location in the sample."""
-        point_zyx = torch.as_tensor(point_zyx, device=self.device).float()
-        point_zyx = point_zyx.reshape((-1, 3))
-        rotation_matrices = self.projection_matrices[:, :3, :3]
-        rotation_matrices = torch.linalg.pinv(rotation_matrices)
-        sidelength_padded = int(self._pad_factor * sidelength)
-        particle_tilt_series = self.extract_particle_tilt_series(
-            point_zyx, sidelength=sidelength_padded
-        )
-        volume = backproject_2d_to_3d(
-            images=particle_tilt_series[0],
-            rotation_matrices=rotation_matrices,
-            zyx_matrices=True,
-            pad_factor=1.0,  # we already incorporate padding in subtilts
-            fftfreq_max=0.5,
-        )
-        p = (sidelength_padded - sidelength) // 2
-        volume = F.pad(volume, [-p] * 6)  # remove padding
-        return volume
+        """Reconstruct a 3D patch at a location in the sample."""
+        # Use batched method and extract first result
+        patches = self.reconstruct_patches_batched(point_zyx, sidelength)
+        return patches[0]
 
     def reconstruct_tomogram(
         self, volume_shape: tuple[int, int, int], sidelength: int
     ) -> torch.Tensor:
-        """Reconstruct the full tomogram by tiling the positions in 3D."""
+        """Reconstruct the full tomogram by tiling reconstructed patches in 3D. """
         d, h, w = volume_shape
         r = sidelength // 2
 
-        # setup grid points
-        z = torch.arange(start=r, end=d + r, step=sidelength) - d // 2
-        y = torch.arange(start=r, end=h + r, step=sidelength) - h // 2
-        x = torch.arange(start=r, end=w + r, step=sidelength) - w // 2
+        # Setup grid points where patches will be reconstructed
+        z = torch.arange(start=r, end=d + r, step=sidelength, device=self.device) - d // 2
+        y = torch.arange(start=r, end=h + r, step=sidelength, device=self.device) - h // 2
+        x = torch.arange(start=r, end=w + r, step=sidelength, device=self.device) - w // 2
 
-        # allocate whole volume
-        tomogram = torch.zeros(
-            size=volume_shape, dtype=torch.float32, device=self.device
+        # Create grid of all positions: (n_z, n_y, n_x, 3)
+        grid_zyx = torch.stack(torch.meshgrid(z, y, x, indexing='ij'), dim=-1)
+        original_shape = grid_zyx.shape[:-1]  # (n_z, n_y, n_x)
+        grid_zyx = grid_zyx.reshape(-1, 3)  # (N, 3) where N = n_z * n_y * n_x
+        
+        # Reconstruct all patches at once
+        patches = self.reconstruct_patches_batched(
+            points_zyx=grid_zyx, 
+            sidelength=sidelength
+        )  # (N, sidelength, sidelength, sidelength)
+        
+        # Reshape back to grid structure: (n_z, n_y, n_x, sidelength, sidelength, sidelength)
+        patches = patches.reshape(*original_shape, sidelength, sidelength, sidelength)
+        
+        # Tile all patches into the full volume
+        tomogram = einops.rearrange(
+            patches,
+            'nz ny nx d h w -> (nz d) (ny h) (nx w)'
         )
-
-        for _z in z:
-            for _y in y:
-                for _x in x:
-                    zyx = torch.tensor([_z, _y, _x]).float()
-                    subvolume = self.reconstruct_subvolume(zyx, sidelength=sidelength)
-                    _d, _h, _w = zyx + torch.tensor(volume_shape) // 2
-                    _d, _h, _w = int(_d), int(_h), int(_w)
-                    d_min, d_max = _d - r, min(_d + r, d)
-                    h_min, h_max = _h - r, min(_h + r, h)
-                    w_min, w_max = _w - r, min(_w + r, w)
-                    d_max_sub = d_max - d_min
-                    h_max_sub = h_max - h_min
-                    w_max_sub = w_max - w_min
-                    tomogram[d_min:d_max, h_min:h_max, w_min:w_max] = subvolume[
-                        :d_max_sub, :h_max_sub, :w_max_sub
-                    ]
+        
+        # Crop to desired volume shape 
+        tomogram = tomogram[:d, :h, :w]
+        
         return tomogram
+    
+    def reconstruct_patches_batched(
+        self, points_zyx: torch.Tensor, sidelength: int
+    ) -> torch.Tensor:
+        """Reconstruct multiple 3D patches simultaneously from 2D projections. """
+        points_zyx = torch.as_tensor(points_zyx, device=self.device).float()
+        if points_zyx.ndim == 1:
+            points_zyx = points_zyx.reshape(1, 3)
+        
+        n_positions = points_zyx.shape[0]
+        rotation_matrices = self.projection_matrices[:, :3, :3]
+        rotation_matrices = torch.linalg.pinv(rotation_matrices)
+        sidelength_padded = int(self._pad_factor * sidelength)
+        
+        # Extract patches (batched)
+        particle_tilt_series_rfft = self.extract_particle_tilt_series(
+            points_zyx, sidelength=sidelength_padded, return_rfft=True
+        )  # (n_positions, n_tilts, h, w_rfft)
+        
+        particle_tilt_series_rfft = torch.fft.fftshift(
+            particle_tilt_series_rfft, dim=(-2,)
+        )  # (n_positions, n_tilts, h, w_rfft)
+        
+        # Transpose to multichannel format: (n_tilts, n_positions, h, w_rfft)
+        # where n_tilts is the batch dim and n_positions is the channel dim
+        particle_tilt_series_rfft = particle_tilt_series_rfft.transpose(0, 1)
+        
+        # Reconstruct all patches at once using multichannel insertion
+        # Treat each patch as a separate "channel"
+        patches_rfft, weights = insert_central_slices_rfft_3d_multichannel(
+            image_rfft=particle_tilt_series_rfft,
+            volume_shape=(sidelength_padded, sidelength_padded, sidelength_padded),
+            rotation_matrices=rotation_matrices,
+            zyx_matrices=True,
+            fftfreq_max=0.5,
+        )  # patches_rfft: (n_positions, d, h, w_rfft), weights: (d, h, w_rfft)
+        
+        # Reweight each patch
+        valid_weights = weights > 1e-3
+        patches_rfft[:, valid_weights] /= weights[valid_weights]
+        
+        patches_rfft = torch.fft.ifftshift(patches_rfft, dim=(-3, -2))
+
+        patches = torch.fft.irfftn(
+            patches_rfft, 
+            s=(sidelength_padded,) * 3, 
+            dim=(-3, -2, -1)
+        )  # (n_positions, d, h, w)
+        
+        # Center all patches in real space
+        patches = torch.fft.ifftshift(patches, dim=(-3, -2, -1))
+        
+        # Correct for convolution with linear interpolation kernel
+        grid = fftfreq_grid(
+            image_shape=(sidelength_padded, sidelength_padded, sidelength_padded), 
+            rfft=False, fftshift=True, norm=True, device=self.device
+        )
+        patches = patches / torch.sinc(grid) ** 2
+        
+        # Remove padding from all patches
+        p = (sidelength_padded - sidelength) // 2
+        patches = F.pad(patches, [-p] * 6)
+        
+        return patches

--- a/tests/test_torch_tomogram.py
+++ b/tests/test_torch_tomogram.py
@@ -133,15 +133,22 @@ def test_extract_particle_tilt_series(device):
     # Create a single 3D point at the origin
     points_zyx = torch.tensor([[0.0, 0.0, 0.0]], device=device)
 
-    # Extract particle tilt series
+    # Extract particle tilt series in real space
     particle_tilt_series = tomogram.extract_particle_tilt_series(
-        points_zyx, sidelength=8
+        points_zyx, sidelength=8, return_rfft=False
     )
 
     # Check shape and type
     assert particle_tilt_series.shape == (1, 3, 8, 8)  # 1 point, 3 tilts, 8x8 images
     assert particle_tilt_series.dtype == torch.float32
     assert device in str(particle_tilt_series.device)
+    
+    # Also test Fourier space extraction
+    particle_tilt_series_rfft = tomogram.extract_particle_tilt_series(
+        points_zyx, sidelength=8, return_rfft=True
+    )
+    assert particle_tilt_series_rfft.shape == (1, 3, 8, 5)  # rfft: width = 8//2 + 1 = 5
+    assert particle_tilt_series_rfft.dtype == torch.complex64
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
@McHaillet @alisterburt with this commit I tried to address #12 #13 #15 #16. Sorry if it comes as a single commit, but I thought that they were largely interconnected. A short summary:

RE: #12 get DFT patches from torch-subpixel-crop:
Added support for Fourier space patch extraction using return_rfft=True in subpixel_crop_2d. Patches are now extracted directly in Fourier space and passed to insert_central_slices_rfft_3d_multichannel for reconstruction. That is the same as before, with backproject_2d_to_3d from torch-fourier-slice, but skipping one FFT step. I like the clarity here, but maybe it's too redundant. Do you think it would be better to directly add the option to backproject_2d_to_3d, or do you have a more streamlined way of reconstruction in mind?

RE: #13 batched reconstruction:
All patches at all positions are now reconstructed simultaneously using the multichannel from insert_central_slices_rfft_3d_multichannel. Added reconstruct_patches_batched() method that should processes everything in parallel.  For tiling I swapped the for loop with einops.rearrange.

RE #15 class methods to load etomo and aretomo data directly:
Added Tomogram.from_etomo_directory() and Tomogram.from_aretomo_aln() class methods. I like the idea of only providing the path and then having everything handled within torch-tomogram (I updated the examples for both etomo and aretomo reconstruction to show what it would look like). However, perhaps providing the dataframe as input might offer more flexibility? 

RE #16 define translations in Angstroms:
Added optional pixel_spacing parameter. When provided, sample_translations are stored in Angstroms and converted to pixels internally via sample_translations_px. Not sure if that was the way you were envisioning this, though

I tested it on my data and it all works fine.
I'd love to know what you guys think! 
